### PR TITLE
Added a plot interface and a very simple cli

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["pandas"]
+dependencies = ["matplotlib","pandas"]
 
 [project.urls]
 Documentation = "https://github.com//plumed-bench-pp#readme"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "plumed-bench-pp"
 dynamic = ["version"]
-description = ""
+description = "A simpe package to rapidly postprocessing the output of plumed benchmarks"
 readme = "README.md"
 requires-python = ">=3.9"
 license = "MIT"
@@ -23,12 +23,15 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["matplotlib","pandas"]
+dependencies = ["matplotlib","pandas","click"]
 
 [project.urls]
-Documentation = "https://github.com//plumed-bench-pp#readme"
-Issues = "https://github.com//plumed-bench-pp/issues"
-Source = "https://github.com//plumed-bench-pp"
+Documentation = "https://github.com/Iximiel/plumed-bench-pp#readme"
+Issues = "https://github.com/Iximiel/plumed-bench-pp/issues"
+Source = "https://github.com/Iximiel/plumed-bench-pp"
+
+[project.scripts]
+plmdbpp = "plumed_bench_pp.cli:plmdbpp"
 
 [tool.hatch.version]
 path = "src/plumed_bench_pp/__about__.py"

--- a/src/plumed_bench_pp/cli/__init__.py
+++ b/src/plumed_bench_pp/cli/__init__.py
@@ -3,11 +3,12 @@
 # SPDX-License-Identifier: MIT
 import click
 
-import plumed_bench_pp.constants as plmdconst
+# import plumed_bench_pp.constants as plmdconst
 from plumed_bench_pp.__about__ import __version__
-from plumed_bench_pp.parser import parse_full_benchmark_output
-from plumed_bench_pp.plot import plot_histo
-from plumed_bench_pp.tabulate import convert_to_table
+
+# from plumed_bench_pp.parser import parse_full_benchmark_output
+# from plumed_bench_pp.plot import plot_histo
+# from plumed_bench_pp.tabulate import convert_to_table
 
 
 @click.group(context_settings={"help_option_names": ["-h", "--help"]}, invoke_without_command=True)

--- a/src/plumed_bench_pp/cli/__init__.py
+++ b/src/plumed_bench_pp/cli/__init__.py
@@ -3,9 +3,8 @@
 # SPDX-License-Identifier: MIT
 import click
 
-#TODO: suggest this
-#https://click.palletsprojects.com/en/8.1.x/shell-completion/
-
+# TODO: suggest this
+# https://click.palletsprojects.com/en/8.1.x/shell-completion/
 import plumed_bench_pp.utils as pbpputils
 from plumed_bench_pp.__about__ import __version__
 from plumed_bench_pp.constants import (
@@ -41,7 +40,7 @@ row_choiches = {
 }
 
 
-def get_filelist(files: click.Path):
+def get_filelist(files: "tuple[str]") -> list:
     filelist = []
 
     for f in files:
@@ -59,7 +58,7 @@ def get_data(filelist, rows):
 
 
 @click.command()
-@click.argument("files", type=click.Path(exists=True), nargs=-1)
+@click.argument("files", type=click.Path(readable=True), nargs=-1)
 def kernels(files):
     """List the kernels in the given files"""
     filelist = get_filelist(files)
@@ -69,7 +68,7 @@ def kernels(files):
 
 
 @click.command()
-@click.argument("files", type=click.Path(exists=True), nargs=-1)
+@click.argument("files", type=click.Path(readable=True), nargs=-1)
 @click.option("--output", "-o", type=click.STRING, help="The output file to write the plot to")
 @click.option(
     "--row",
@@ -83,27 +82,59 @@ def plot(files, output, row):
     """Plot the data in the given files
 
     This assumes that the simulation data is given in kernels"""
+    from os.path import commonpath
+
     import matplotlib.pyplot as plt
 
+    from plumed_bench_pp.plot import plot_histo
     # import matplotlib
-    # matplotlib.use('Agg')
+    # # matplotlib.use('Agg')
     # print(f"Interactive mode: {matplotlib.is_interactive()}")
     # print(f"matplotlib backend: {matplotlib.rcParams['backend']}")
-    from plumed_bench_pp.plot import plot_histo
 
-    click.echo(f"{row=}")
     rowtoplot = row_choiches[row]
-    # click.echo(f"{files=}")
-    # click.echo(f"{output=}")
-    filelist = get_filelist(files)
-    data = get_data(filelist, ["Plumed"])
-    fig, ax = plt.subplots()
-    plot_histo(ax, [data[k] for k in pbpputils.get_kernels(filelist)], rowtoplot)
 
+    filelist = get_filelist(files)
+    data = get_data(filelist, [rowtoplot])
+    fig, ax = plt.subplots()
+    kernels = list(pbpputils.get_kernels(filelist))
+    cpf = commonpath(kernels)
+    titles = [k[len(cpf) :] for k in kernels]
+
+    plot_histo(ax, [data[k] for k in kernels], rowtoplot, titles=titles)
+    ax.legend()
     if output is None:
         plt.show()
     else:
         fig.savefig(output)
+
+
+@click.command()
+@click.argument("files", type=click.Path(readable=True), nargs=-1)
+@click.option(
+    "--rows",
+    "-r",
+    type=click.Choice(list(row_choiches.keys())),
+    multiple=True,
+    default=["TOTALTIME"],
+    help="The row(s) to plot",
+)
+def show(files, rows):
+    """Show on the screen the accumulated results of benchmark from the given files
+
+    This assumes that the simulation data is given in kernels"""
+
+    rowstoplot = [row_choiches[row] for row in rows]
+    filelist = get_filelist(files)
+    data = get_data(filelist, rowstoplot)
+    kernels = list(pbpputils.get_kernels(filelist))
+
+    for k in kernels:
+        click.echo("Kernel: ")
+        click.echo(click.style(k, bold=True))
+        for r in rowstoplot:
+            click.echo(click.style(r, fg="red", bold=True))
+            click.echo(data[k][r])
 
 
 @click.group(context_settings={"help_option_names": ["-h", "--help"]}, invoke_without_command=True)
@@ -114,3 +145,4 @@ def plmdbpp():
 
 plmdbpp.add_command(kernels)
 plmdbpp.add_command(plot)
+plmdbpp.add_command(show)

--- a/src/plumed_bench_pp/cli/__init__.py
+++ b/src/plumed_bench_pp/cli/__init__.py
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: 2024-present Daniele Rapetti <iximiel@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+import click
+
+import plumed_bench_pp.constants as plmdconst
+from plumed_bench_pp.__about__ import __version__
+from plumed_bench_pp.parser import parse_full_benchmark_output
+from plumed_bench_pp.plot import plot_histo
+from plumed_bench_pp.tabulate import convert_to_table
+
+
+@click.group(context_settings={"help_option_names": ["-h", "--help"]}, invoke_without_command=True)
+@click.version_option(version=__version__, prog_name="plmdbpp")
+def plmdbpp():
+    click.echo("Hello world!")

--- a/src/plumed_bench_pp/cli/__init__.py
+++ b/src/plumed_bench_pp/cli/__init__.py
@@ -3,15 +3,74 @@
 # SPDX-License-Identifier: MIT
 import click
 
+import plumed_bench_pp.utils as pbpputils
+
 # import plumed_bench_pp.constants as plmdconst
 from plumed_bench_pp.__about__ import __version__
+from plumed_bench_pp.parser import parse_full_benchmark_output
 
-# from plumed_bench_pp.parser import parse_full_benchmark_output
 # from plumed_bench_pp.plot import plot_histo
-# from plumed_bench_pp.tabulate import convert_to_table
+from plumed_bench_pp.tabulate import convert_to_table
+
+
+def get_filelist(files:click.Path):
+    filelist = []
+
+    for f in files:
+        with open(f) as ff:
+            filelist.append(parse_full_benchmark_output(ff.readlines()))
+
+    return filelist
+
+def get_data(filelist,rows):
+    data={}
+    for k in pbpputils.get_kernels(filelist):
+            data[k] = convert_to_table(filelist, rows, kernel=
+            k, inputlist=".dat")
+    return data
+
+
+@click.command()
+@click.argument("files", type=click.Path(exists=True), nargs=-1)
+def kernels(files):
+    """List the kernels in the given files"""
+    filelist = get_filelist(files)
+
+
+    for p in pbpputils.get_kernels(filelist):
+        click.echo(p)
+
+
+@click.command()
+@click.argument("files", type=click.Path(exists=True), nargs=-1)
+@click.option("--output", "-o", type=click.STRING)
+def plot(files, output):
+    """Plot the data in the given files
+    
+    This assumes that the simulation data is given in kernels"""
+    import matplotlib.pyplot as plt 
+    # import matplotlib
+    # matplotlib.use('Agg')
+    from plumed_bench_pp.plot import plot_histo
+    
+    # click.echo(f"{files=}")
+    # click.echo(f"{output=}")
+    filelist = get_filelist(files)
+    data = get_data(filelist, ["Plumed"])
+    fig, ax=plt.subplots()
+    plot_histo(ax,[data[k] for k in pbpputils.get_kernels(filelist)],"Plumed")
+
+    if output is None:
+        plt.show()
+    else:
+        fig.savefig(output)
 
 
 @click.group(context_settings={"help_option_names": ["-h", "--help"]}, invoke_without_command=True)
 @click.version_option(version=__version__, prog_name="plmdbpp")
 def plmdbpp():
-    click.echo("Hello world!")
+    pass
+
+
+plmdbpp.add_command(kernels)
+plmdbpp.add_command(plot)

--- a/src/plumed_bench_pp/plot.py
+++ b/src/plumed_bench_pp/plot.py
@@ -113,7 +113,7 @@ def plot_histo_relative(
     colors: "list|None" = None,
 ) -> "list[BarContainer]":
     """a shortcut to generate a relative histogram, with relative_to options set as positional arguments"""
-    plot_histo(
+    return plot_histo(
         ax,
         data,
         row,

--- a/src/plumed_bench_pp/plot.py
+++ b/src/plumed_bench_pp/plot.py
@@ -1,0 +1,111 @@
+# SPDX-FileCopyrightText: 2024-present Daniele Rapetti <daniele.rapetti@sissa.it>
+#
+# SPDX-License-Identifier: MIT
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from typing import Any
+
+    from numpy import ndarray
+    from pandas import DataFrame
+from matplotlib.pyplot import Axes
+
+
+def plot_histo(
+    ax: Axes,
+    data: "list[dict]|dict[str,DataFrame]",
+    row: str,
+    barwidth: float = 0.8,
+    *,
+    normalize_to_cycles: "bool|str" = False,
+    x: "ndarray|None" = None,
+    colors: "list|None" = None,
+    relative_to: "dict[str, DataFrame]| Any" = None,
+    relative_to_row: "str|None" = None,
+):
+    """
+    Plot a histogram based on the provided data for a specified row.
+
+    It can be set up to normalize the data to cycles or relative to another row.
+    It can be set up to use a custom x-axis or colors for the bars.
+    It can be set up to plot relative to another dataset, dividing the value of each olume by that number.
+
+    Parameters:
+        ax (Axes): The matplotlib axes to plot the histogram.
+        data (list[dict]|dict[str,DataFrame]): The data to be plotted.
+        row (str): The row in the data to be plotted.
+        barwidth (float, optional): The width of the bars in the histogram. Defaults to 0.8.
+        normalize_to_cycles (bool|str, optional): Flag to normalize data to cycles. Defaults to False.
+        x (np.array|None, optional): The x values for plotting. Defaults to None.
+        colors (list|None, optional): The colors for the bars in the histogram. Defaults to None.
+        relative_to (dict[str, DataFrame]| Any, optional): Data for relative comparison, you can pass a dict contianing the collection of data or the address or index of the desired base in the passed data. Defaults to None.
+        relative_to_row (str|None, optional): The row for relative comparison. Defaults to None.
+
+    Returns:
+        list: The list of plotted bars.
+    """
+    if not isinstance(data, list):
+        data = [data]
+
+    row_cycles = row
+    if isinstance(normalize_to_cycles, str):
+        # row_cycles is introduced because usually the TOTALTIME is a "single cycle"
+        # and the info on the effective number of steps is in the timer relative to apply or calculate
+        row_cycles = normalize_to_cycles
+        normalize_to_cycles = True
+    divideby = 1
+    if relative_to is not None:
+        # relative to mode
+        if not isinstance(relative_to, dict):
+            # in this case relative_to assubed to be the index of the data
+            relative_to = data[relative_to]
+        if relative_to_row is None:
+            relative_to_row = row
+        divideby = relative_to[relative_to_row].Total.values
+        if normalize_to_cycles:
+            divideby = divideby / relative_to[row_cycles].Cycles.values
+
+    ncols = len(data)
+    if x is None:
+        x = data[0][row].natoms.values
+    width = np.min(np.diff(np.sort(x))) * (barwidth / ncols)
+    ax.set_xticks(x + width * 0.5 * (ncols - 1), x)
+    bars = []
+    for multiplier, d in enumerate(data):
+        offset = width * multiplier
+
+        toplot = d[row].Total.values
+        if normalize_to_cycles:
+            toplot = toplot / d[row_cycles].Cycles.values
+        toplot = toplot / divideby
+        bars.append(ax.bar(x + offset, toplot, width, color=colors[multiplier] if colors else None))
+    return bars
+
+
+def plot_histo_relative(
+    ax: Axes,
+    data: "list[dict]|dict[str,DataFrame]",
+    row: str,
+    relative_to: "dict[str, DataFrame]| Any",
+    relative_to_row: "str|None" = None,
+    *,
+    barwidth: float = 0.8,
+    normalize_to_cycles: "bool|str" = False,
+    x: "ndarray|None" = None,
+    colors: "list|None" = None,
+):
+    """a shortcut to generate a relative histogram"""
+    plot_histo(
+        ax,
+        data,
+        row,
+        barwidth=barwidth,
+        normalize_to_cycles=normalize_to_cycles,
+        x=x,
+        colors=colors,
+        relative_to=relative_to,
+        relative_to_row=relative_to_row,
+    )

--- a/src/plumed_bench_pp/plot.py
+++ b/src/plumed_bench_pp/plot.py
@@ -9,8 +9,10 @@ import numpy as np
 if TYPE_CHECKING:
     from typing import Any
 
+    from matplotlib.container import BarContainer
     from numpy import ndarray
     from pandas import DataFrame
+
 from matplotlib.pyplot import Axes
 
 
@@ -25,7 +27,7 @@ def plot_histo(
     colors: "list|None" = None,
     relative_to: "dict[str, DataFrame]| Any" = None,
     relative_to_row: "str|None" = None,
-):
+) -> "list[BarContainer]":
     """
     Plot a histogram based on the provided data for a specified row.
 
@@ -91,13 +93,13 @@ def plot_histo_relative(
     row: str,
     relative_to: "dict[str, DataFrame]| Any",
     relative_to_row: "str|None" = None,
-    *,
     barwidth: float = 0.8,
+    *,
     normalize_to_cycles: "bool|str" = False,
     x: "ndarray|None" = None,
     colors: "list|None" = None,
-):
-    """a shortcut to generate a relative histogram"""
+) -> "list[BarContainer]":
+    """a shortcut to generate a relative histogram, with relative_to options set as positional arguments"""
     plot_histo(
         ax,
         data,

--- a/src/plumed_bench_pp/plot.py
+++ b/src/plumed_bench_pp/plot.py
@@ -27,6 +27,7 @@ def plot_histo(
     colors: "list|None" = None,
     relative_to: "dict[str, DataFrame]| Any" = None,
     relative_to_row: "str|None" = None,
+    titles: "list[str]|None" = None,
 ) -> "list[BarContainer]":
     """
     Plot a histogram based on the provided data for a specified row.
@@ -83,7 +84,19 @@ def plot_histo(
         if normalize_to_cycles:
             toplot = toplot / d[row_cycles].Cycles.values
         toplot = toplot / divideby
-        bars.append(ax.bar(x + offset, toplot, width, color=colors[multiplier] if colors else None))
+        xpos = x
+        if len(x) > len(d[row].natoms.values):
+            # with this if a natom is missing it does not create errors, this will conflict is x is inpute as not None
+            xpos = d[row].natoms.values
+        bars.append(
+            ax.bar(
+                xpos + offset,
+                toplot,
+                width,
+                color=colors[multiplier] if colors else None,
+                label=titles[multiplier] if titles else None,
+            )
+        )
     return bars
 
 

--- a/src/plumed_bench_pp/tabulate.py
+++ b/src/plumed_bench_pp/tabulate.py
@@ -8,8 +8,8 @@ import re
 from pandas import DataFrame
 
 from plumed_bench_pp.constants import TIMINGCOLS
-
 from plumed_bench_pp.utils import _common_iterable
+
 
 def _checkfile(fname: str, pattern: "str|list[str]|re.Pattern") -> bool:
     """

--- a/src/plumed_bench_pp/tabulate.py
+++ b/src/plumed_bench_pp/tabulate.py
@@ -7,10 +7,9 @@ import re
 
 from pandas import DataFrame
 
-from plumed_bench_pp.constants import (
-    TIMINGCOLS,
-)
+from plumed_bench_pp.constants import TIMINGCOLS
 
+from plumed_bench_pp.utils import _common_iterable
 
 def _checkfile(fname: str, pattern: "str|list[str]|re.Pattern") -> bool:
     """
@@ -50,18 +49,11 @@ def convert_to_table(
         A dictionary where keys are row names and values are DataFrames containing the extracted data.
     """
 
-    def common_iterable(obj):
-        """Iterates over the values of a dict or any iterable"""
-        if isinstance(obj, dict):
-            yield from obj.values()
-        else:
-            yield from obj
-
     data: dict[str, DataFrame] = {}
     tmp: dict = {}
     for row in rows_to_extract:
         tmp[row] = []
-    for file in common_iterable(filesdict):
+    for file in _common_iterable(filesdict):
         key = None
         for k in file.runs:
             if (file.runs[k].kernel == kernel) and _checkfile(file.runs[k].input, inputlist):

--- a/src/plumed_bench_pp/utils.py
+++ b/src/plumed_bench_pp/utils.py
@@ -7,6 +7,8 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
+from plumed_bench_pp.types import BenchmarkRun
+
 
 def _append_kernel_rec(keys: "list[str] | Iterable[str]", name: str, level: int) -> str:
     nm = name if level == 0 else f"{name}({level})"
@@ -14,12 +16,13 @@ def _append_kernel_rec(keys: "list[str] | Iterable[str]", name: str, level: int)
         return _append_kernel_rec(keys, name, level + 1)
     return nm
 
+
 def _common_iterable(obj):
-        """Iterates over the values of a dict or any iterable"""
-        if isinstance(obj, dict):
-            yield from obj.values()
-        else:
-            yield from obj
+    """Iterates over the values of a dict or any iterable"""
+    if isinstance(obj, dict):
+        yield from obj.values()
+    else:
+        yield from obj
 
 
 def kernel_name(data: dict, name: str) -> str:
@@ -28,16 +31,16 @@ def kernel_name(data: dict, name: str) -> str:
 
 # TODO: add a extract filenames extract and extract kernel+file combination
 
+
 def get_kernels(data: dict) -> set[str]:
-    toret=[]
-    if isinstance(data, dict) and "BENCHSETTINGS" in data.keys():
-        data=[data]
+    toret = []
+    if isinstance(data, BenchmarkRun):
+        data = [data]
     for d in _common_iterable(data):
-        for k in d:
-            if k == "BENCHSETTINGS":
-                continue
-            toret.append(d[k]["kernel"])
+        toret + [d.runs[k].kernel for k in d.runs]
 
     return set(toret)
 
-def get_files(data: dict) -> set[str]:
+
+# def get_files(data: dict) -> set[str]:
+#     pass

--- a/src/plumed_bench_pp/utils.py
+++ b/src/plumed_bench_pp/utils.py
@@ -37,10 +37,16 @@ def get_kernels(data: dict) -> set[str]:
     if isinstance(data, BenchmarkRun):
         data = [data]
     for d in _common_iterable(data):
-        toret + [d.runs[k].kernel for k in d.runs]
+        toret += [d.runs[k].kernel for k in d.runs]
 
     return set(toret)
 
 
-# def get_files(data: dict) -> set[str]:
-#     pass
+def get_inputfiles(data: dict) -> set[str]:
+    toret = []
+    if isinstance(data, BenchmarkRun):
+        data = [data]
+    for d in _common_iterable(data):
+        toret += [d.runs[k].input for k in d.runs]
+
+    return set(toret)

--- a/src/plumed_bench_pp/utils.py
+++ b/src/plumed_bench_pp/utils.py
@@ -29,9 +29,6 @@ def kernel_name(data: dict, name: str) -> str:
     return _append_kernel_rec(data.keys(), name, 0)
 
 
-# TODO: add a extract filenames extract and extract kernel+file combination
-
-
 def get_kernels(data: dict) -> set[str]:
     toret = []
     if isinstance(data, BenchmarkRun):
@@ -50,3 +47,13 @@ def get_inputfiles(data: dict) -> set[str]:
         toret += [d.runs[k].input for k in d.runs]
 
     return set(toret)
+
+
+def get_kernels_and_inputfiles(data: dict) -> list[str]:
+    toret = []
+    if isinstance(data, BenchmarkRun):
+        data = [data]
+    for d in _common_iterable(data):
+        toret += [(d.runs[k].kernel, d.runs[k].input) for k in d.runs]
+
+    return toret

--- a/src/plumed_bench_pp/utils.py
+++ b/src/plumed_bench_pp/utils.py
@@ -29,7 +29,7 @@ def kernel_name(data: dict, name: str) -> str:
     return _append_kernel_rec(data.keys(), name, 0)
 
 
-def get_kernels(data: dict) -> set[str]:
+def get_kernels(data: "BenchmarkRun|list[BenchmarkRun]") -> "set[str]":
     toret = []
     if isinstance(data, BenchmarkRun):
         data = [data]
@@ -39,7 +39,7 @@ def get_kernels(data: dict) -> set[str]:
     return set(toret)
 
 
-def get_inputfiles(data: dict) -> set[str]:
+def get_inputfiles(data: "BenchmarkRun|list[BenchmarkRun]") -> "set[str]":
     toret = []
     if isinstance(data, BenchmarkRun):
         data = [data]
@@ -49,7 +49,7 @@ def get_inputfiles(data: dict) -> set[str]:
     return set(toret)
 
 
-def get_kernels_and_inputfiles(data: dict) -> list[str]:
+def get_kernels_and_inputfiles(data: "BenchmarkRun|list[BenchmarkRun]") -> "list[tuple[str, str]]":
     toret = []
     if isinstance(data, BenchmarkRun):
         data = [data]

--- a/src/plumed_bench_pp/utils.py
+++ b/src/plumed_bench_pp/utils.py
@@ -14,6 +14,30 @@ def _append_kernel_rec(keys: "list[str] | Iterable[str]", name: str, level: int)
         return _append_kernel_rec(keys, name, level + 1)
     return nm
 
+def _common_iterable(obj):
+        """Iterates over the values of a dict or any iterable"""
+        if isinstance(obj, dict):
+            yield from obj.values()
+        else:
+            yield from obj
+
 
 def kernel_name(data: dict, name: str) -> str:
     return _append_kernel_rec(data.keys(), name, 0)
+
+
+# TODO: add a extract filenames extract and extract kernel+file combination
+
+def get_kernels(data: dict) -> set[str]:
+    toret=[]
+    if isinstance(data, dict) and "BENCHSETTINGS" in data.keys():
+        data=[data]
+    for d in _common_iterable(data):
+        for k in d:
+            if k == "BENCHSETTINGS":
+                continue
+            toret.append(d[k]["kernel"])
+
+    return set(toret)
+
+def get_files(data: dict) -> set[str]:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
-from plumed_bench_pp.utils import get_kernels, kernel_name,get_inputfiles
+from plumed_bench_pp.utils import get_inputfiles, get_kernels, get_kernels_and_inputfiles, kernel_name
 
 
 def test_kernel_name():
@@ -41,6 +41,7 @@ def test_get_inputfiles(incremental_output):
         for run in parsed_input[k].runs.values():
             assert run.input in ret
 
+
 def test_get_kernels_dict(incremental_output):
     parsed_input, _, _ = incremental_output
     ret = get_kernels(parsed_input)
@@ -56,6 +57,7 @@ def test_get_inputfiles_dict(incremental_output):
         for run in myinput.runs.values():
             assert run.input in ret
 
+
 def test_get_kernels_list(incremental_output):
     parsed_input, _, _ = incremental_output
     ret = get_kernels([parsed_input[k] for k in parsed_input])
@@ -63,9 +65,34 @@ def test_get_kernels_list(incremental_output):
         for run in myinput.runs.values():
             assert run.kernel in ret
 
+
 def test_get_inputfiles_list(incremental_output):
     parsed_input, _, _ = incremental_output
     ret = get_inputfiles([parsed_input[k] for k in parsed_input])
     for myinput in parsed_input.values():
         for run in myinput.runs.values():
             assert run.input in ret
+
+
+def test_get_kernels_and_inputfiles(incremental_output):
+    parsed_input, _, _ = incremental_output
+    for myinput in parsed_input.values():
+        ret = get_kernels_and_inputfiles(parsed_input)
+        for run in myinput.runs.values():
+            assert (run.kernel, run.input) in ret
+
+
+def test_get_kernels_and_inputfiles_dict(incremental_output):
+    parsed_input, _, _ = incremental_output
+    ret = get_kernels_and_inputfiles(parsed_input)
+    for myinput in parsed_input.values():
+        for run in myinput.runs.values():
+            assert (run.kernel, run.input) in ret
+
+
+def test_get_kernels_and_inputfiles_list(incremental_output):
+    parsed_input, _, _ = incremental_output
+    ret = get_kernels_and_inputfiles([parsed_input[k] for k in parsed_input])
+    for myinput in parsed_input.values():
+        for run in myinput.runs.values():
+            assert (run.kernel, run.input) in ret

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
-from plumed_bench_pp.utils import get_kernels, kernel_name
+from plumed_bench_pp.utils import get_kernels, kernel_name,get_inputfiles
 
 
 def test_kernel_name():
@@ -30,19 +30,42 @@ def test_get_kernels(incremental_output):
     parsed_input, _, _ = incremental_output
     for k in parsed_input:
         ret = get_kernels(parsed_input[k])
-        assert "this" in ret
-        assert "that" in ret
+        for run in parsed_input[k].runs.values():
+            assert run.kernel in ret
 
+
+def test_get_inputfiles(incremental_output):
+    parsed_input, _, _ = incremental_output
+    for k in parsed_input:
+        ret = get_inputfiles(parsed_input[k])
+        for run in parsed_input[k].runs.values():
+            assert run.input in ret
 
 def test_get_kernels_dict(incremental_output):
     parsed_input, _, _ = incremental_output
     ret = get_kernels(parsed_input)
-    assert "this" in ret
-    assert "that" in ret
+    for myinput in parsed_input.values():
+        for run in myinput.runs.values():
+            assert run.kernel in ret
 
+
+def test_get_inputfiles_dict(incremental_output):
+    parsed_input, _, _ = incremental_output
+    ret = get_inputfiles(parsed_input)
+    for myinput in parsed_input.values():
+        for run in myinput.runs.values():
+            assert run.input in ret
 
 def test_get_kernels_list(incremental_output):
     parsed_input, _, _ = incremental_output
     ret = get_kernels([parsed_input[k] for k in parsed_input])
-    assert "this" in ret
-    assert "that" in ret
+    for myinput in parsed_input.values():
+        for run in myinput.runs.values():
+            assert run.kernel in ret
+
+def test_get_inputfiles_list(incremental_output):
+    parsed_input, _, _ = incremental_output
+    ret = get_inputfiles([parsed_input[k] for k in parsed_input])
+    for myinput in parsed_input.values():
+        for run in myinput.runs.values():
+            assert run.input in ret

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
-from plumed_bench_pp.utils import kernel_name
+from plumed_bench_pp.utils import kernel_name,get_kernels
 
 
 def test_kernel_name():
@@ -24,3 +24,21 @@ def test_kernel_name():
     assert mydict["bar"] == "bar->1"
     assert "bar(1)" in mydict
     assert mydict["bar(1)"] == "bar->0"
+
+def test_get_kernels(incremental_output):
+    parsed_input, _, _ = incremental_output 
+    for k in parsed_input:
+        ret=get_kernels(parsed_input[k])
+        assert "this" in ret
+        assert "that" in ret
+def test_get_kernels_dict(incremental_output):
+    parsed_input, _, _ = incremental_output
+    ret=get_kernels(parsed_input)
+    assert "this" in ret
+    assert "that" in ret
+
+def test_get_kernels_list(incremental_output):
+    parsed_input, _, _ = incremental_output
+    ret=get_kernels([parsed_input[k] for k in parsed_input])
+    assert "this" in ret
+    assert "that" in ret

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
-from plumed_bench_pp.utils import kernel_name,get_kernels
+from plumed_bench_pp.utils import get_kernels, kernel_name
 
 
 def test_kernel_name():
@@ -25,20 +25,24 @@ def test_kernel_name():
     assert "bar(1)" in mydict
     assert mydict["bar(1)"] == "bar->0"
 
+
 def test_get_kernels(incremental_output):
-    parsed_input, _, _ = incremental_output 
+    parsed_input, _, _ = incremental_output
     for k in parsed_input:
-        ret=get_kernels(parsed_input[k])
+        ret = get_kernels(parsed_input[k])
         assert "this" in ret
         assert "that" in ret
+
+
 def test_get_kernels_dict(incremental_output):
     parsed_input, _, _ = incremental_output
-    ret=get_kernels(parsed_input)
+    ret = get_kernels(parsed_input)
     assert "this" in ret
     assert "that" in ret
 
+
 def test_get_kernels_list(incremental_output):
     parsed_input, _, _ = incremental_output
-    ret=get_kernels([parsed_input[k] for k in parsed_input])
+    ret = get_kernels([parsed_input[k] for k in parsed_input])
     assert "this" in ret
     assert "that" in ret


### PR DESCRIPTION
I added a very simple plot interface to produce plots in the style of
![immagine](https://github.com/user-attachments/assets/9b4d7078-b730-48c1-9333-eef0d510eafa)

and a very simple command line interface, with a horrible name, but that can help in visualizing the benchmarks without an ad hoc script:

```
>plmdbpp --help                                                                                      
Usage: plmdbpp [OPTIONS] COMMAND [ARGS]...

Options:
  --version   Show the version and exit.
  -h, --help  Show this message and exit.

Commands:
  kernels  List the kernels in the given files
  plot     Plot the data in the given files
  show     Show on the screen the accumulated results of benchmark from...
```